### PR TITLE
Integrate with `laminas/laminas-cli` instead of `netglue/laminas-symfony-console`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,16 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^8.1",
-        "doctrine/orm": "^2.7",
+        "laminas/laminas-cli": "^0.1.4",
         "laminas/laminas-component-installer": "^2.1",
         "laminas/laminas-config-aggregator": "^1.2",
         "laminas/laminas-servicemanager": "^3.4",
-        "netglue/laminas-symfony-console": "^0.0.1",
         "phpunit/phpunit": "^9.0",
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "suggest": {
-        "netglue/laminas-symfony-console": "To auto-wire symfony cli commands into your DI container"
+        "laminas/laminas-cli": "To auto-wire symfony cli commands into your DI container with laminas/laminas-cli"
     },
     "autoload": {
         "psr-4": {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -17,7 +17,7 @@ class ConfigProvider
             'symfony' => [
                 'messenger' => $this->messengerConfig(),
             ],
-            'console' => $this->consoleConfig(),
+            'laminas-cli' => $this->consoleConfig(),
         ];
     }
 

--- a/src/FailureCommandsConfigProvider.php
+++ b/src/FailureCommandsConfigProvider.php
@@ -17,7 +17,7 @@ class FailureCommandsConfigProvider
     {
         return [
             'dependencies' => $this->dependencies(),
-            'console' => $this->consoleConfig(),
+            'laminas-cli' => $this->consoleConfig(),
         ];
     }
 

--- a/tests/LaminasCliIntegrationTest.php
+++ b/tests/LaminasCliIntegrationTest.php
@@ -23,14 +23,14 @@ final class LaminasCliIntegrationTest extends TestCase
     /** @var ServiceManager */
     private $container;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->cliApplication = (new ApplicationFactory())($this->getContainer());
     }
 
-    private function getContainer() : ContainerInterface
+    private function getContainer(): ContainerInterface
     {
         if ($this->container) {
             return $this->container;
@@ -69,7 +69,7 @@ final class LaminasCliIntegrationTest extends TestCase
     }
 
     /** @dataProvider expectedCommandNameDataProvider */
-    public function testCommandsAreAvailableToTheCliApplication(string $commandName) : void
+    public function testCommandsAreAvailableToTheCliApplication(string $commandName): void
     {
         self::assertTrue($this->cliApplication->has($commandName));
     }

--- a/tests/LaminasCliIntegrationTest.php
+++ b/tests/LaminasCliIntegrationTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\PsrContainer\MessengerTest;
+
+use Laminas\Cli\ApplicationFactory;
+use Laminas\ConfigAggregator\ArrayProvider;
+use Laminas\ConfigAggregator\ConfigAggregator;
+use Laminas\ServiceManager\ServiceManager;
+use Netglue\PsrContainer\Messenger\ConfigProvider;
+use Netglue\PsrContainer\Messenger\FailureCommandsConfigProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Transport\Sync\SyncTransport;
+
+final class LaminasCliIntegrationTest extends TestCase
+{
+    /** @var Application */
+    private $cliApplication;
+    /** @var ServiceManager */
+    private $container;
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->cliApplication = (new ApplicationFactory())($this->getContainer());
+    }
+
+    private function getContainer() : ContainerInterface
+    {
+        if ($this->container) {
+            return $this->container;
+        }
+
+        $aggregator = new ConfigAggregator([
+            ConfigProvider::class,
+            FailureCommandsConfigProvider::class,
+            new ArrayProvider([
+                'symfony' => [
+                    'messenger' => ['failure_transport' => 'failure'],
+                ],
+                'dependencies' => [
+                    'services' => [
+                        'failure' => new SyncTransport(new MessageBus()),
+                    ],
+                ],
+            ]),
+        ]);
+
+        $config = $aggregator->getMergedConfig();
+        $dependencies = $config['dependencies'];
+        $dependencies['services']['config'] = $config;
+        $this->container = new ServiceManager($dependencies);
+
+        return $this->container;
+    }
+
+    /** @return iterable<string, string[]> */
+    public function expectedCommandNameDataProvider(): iterable
+    {
+        $config = $this->getContainer()->get('config')['laminas-cli']['commands'];
+        foreach ($config as $commandName => $identifier) {
+            yield $commandName => [$commandName];
+        }
+    }
+
+    /** @dataProvider expectedCommandNameDataProvider */
+    public function testCommandsAreAvailableToTheCliApplication(string $commandName) : void
+    {
+        self::assertTrue($this->cliApplication->has($commandName));
+    }
+}


### PR DESCRIPTION
Change configuration so that the console commands are keyed with 'laminas-cli', thereby integrating with the laminas cli package and create an integration test to make sure that all the expected commands are available in the cli application that would be returned by the application factory shipped with laminas-cli