### PR TITLE
Added ability to configure additional transport factories

### DIFF
--- a/docs/example-custom-transport-factory.php
+++ b/docs/example-custom-transport-factory.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+use Laminas\ServiceManager\Factory\InvokableFactory;
+use Netglue\PsrContainer\Messenger\Container\TransportFactory;
+
+/**
+ * If you want to use a transport with not supported by Messenger, you can configure a custom transport factory
+ */
+return [
+    'symfony' => [
+        'messenger' => [
+            'transport_factories' => [
+                // a class implementing TransportFactoryInterface
+                \My\Custom\TransportFactory::class
+            ],
+            'transports' => [
+                'my.custom.transport' => [
+                    // any configuration the custom transport needs
+                    'dsn' => 'custom:/foo',
+                ],
+            ],
+        ],
+    ],
+    'dependencies' => [
+        'factories' => [
+            'my.custom.transport' => [TransportFactory::class, 'my.custom.transport'],
+            /**
+             * You must provide a factory for your custom transport factory
+             */
+            \My\Custom\TransportFactory::class => InvokableFactory::class,
+        ],
+    ],
+];

--- a/tests/TransportFactoryFactoryTest.php
+++ b/tests/TransportFactoryFactoryTest.php
@@ -5,16 +5,19 @@ declare(strict_types=1);
 namespace Netglue\PsrContainer\MessengerTest;
 
 use Netglue\PsrContainer\Messenger\Container\DoctrineTransportFactory;
+use Netglue\PsrContainer\Messenger\Exception\ConfigurationError;
 use Netglue\PsrContainer\Messenger\Exception\UnknownTransportScheme;
 use Netglue\PsrContainer\Messenger\TransportFactoryFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use stdClass;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransportFactory;
 use Symfony\Component\Messenger\Transport\InMemoryTransportFactory;
 use Symfony\Component\Messenger\Transport\RedisExt\RedisTransportFactory;
 use Symfony\Component\Messenger\Transport\Sync\SyncTransportFactory;
+use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 
 class TransportFactoryFactoryTest extends TestCase
 {
@@ -58,6 +61,64 @@ class TransportFactoryFactoryTest extends TestCase
         $factory = new TransportFactoryFactory();
         $result = $factory('sync://message_bus', $this->container);
         self::assertInstanceOf(SyncTransportFactory::class, $result);
+    }
+
+    public function testThatConfiguredFactoryReturnsFactory(): void
+    {
+        $dsn = 'valid://foo';
+        $validFactory = $this->createStub(TransportFactoryInterface::class);
+        $validFactory->method('supports')
+            ->with($dsn, [])
+            ->willReturn(true);
+
+        $config = [
+            'symfony' => [
+                'messenger' => [
+                    'transport_factories' => ['test-factory'],
+                ],
+            ],
+        ];
+
+        $this->container->method('has')
+            ->with('config')
+            ->willReturn(true);
+        $this->container->method('get')
+            ->willReturnMap([
+                ['config', $config],
+                ['test-factory', $validFactory],
+            ]);
+
+        $factory = new TransportFactoryFactory();
+        $result = $factory('valid://foo', $this->container);
+        self::assertSame($validFactory, $result);
+    }
+
+    public function testThatConfiguredInvalidFactoryThrowsConfigurationException(): void
+    {
+        $dsn = 'invalid://foo';
+        $invalidFactory = new stdClass();
+
+        $config = [
+            'symfony' => [
+                'messenger' => [
+                    'transport_factories' => ['test-factory'],
+                ],
+            ],
+        ];
+
+        $this->container->method('has')
+            ->with('config')
+            ->willReturn(true);
+        $this->container->method('get')
+            ->willReturnMap([
+                ['config', $config],
+                ['test-factory', $invalidFactory],
+            ]);
+
+        $factory = new TransportFactoryFactory();
+
+        $this->expectException(ConfigurationError::class);
+        $factory($dsn, $this->container);
     }
 
     public function testExceptionThrownForUnknownTransportScheme(): void


### PR DESCRIPTION
Great package (once I got my head round all the configuration :grin:)

I need to be able to add transports not supported by Messenger and couldn't find a way to do it. This PR adds a `transport_factories` configuration option to support this. 