### PR TITLE
Add conflicts for redis and amqp transports >= 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,11 @@
         "psalm/plugin-phpunit": "^0.18.4",
         "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.7.1",
-        "symfony/redis-messenger": "^5.4.15",
         "vimeo/psalm": "^5.2"
+    },
+    "conflict": {
+        "symfony/redis-messenger": ">=6",
+        "symfony/amqp-messenger": ">=6"
     },
     "suggest": {
         "laminas/laminas-cli": "To auto-wire symfony cli commands into your DI container with laminas/laminas-cli"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6de423520c89b4bd109079fc19c44d86",
+    "content-hash": "033b65e27c0a70cd1e8657d32bc7017f",
     "packages": [
         {
             "name": "doctrine/cache",


### PR DESCRIPTION
These conflicts will be removed when `symfony/messenger:^6.0` is supported in the next major