### PR TITLE
Add the final keyword wherever possible

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -7,7 +7,7 @@ namespace Netglue\PsrContainer\Messenger;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Symfony\Component\Messenger as SymfonyMessenger;
 
-class ConfigProvider
+final class ConfigProvider
 {
     /** @return mixed[] */
     public function __invoke(): array

--- a/src/Container/Command/ConsumeCommandFactory.php
+++ b/src/Container/Command/ConsumeCommandFactory.php
@@ -16,7 +16,7 @@ use Symfony\Component\Messenger\RoutableMessageBus;
 
 use function array_keys;
 
-class ConsumeCommandFactory
+final class ConsumeCommandFactory
 {
     use FailureTransportRetrievalBehaviour;
 

--- a/src/Container/Command/DebugCommandFactory.php
+++ b/src/Container/Command/DebugCommandFactory.php
@@ -9,7 +9,7 @@ use Symfony\Component\Messenger\Command\DebugCommand;
 
 use function is_string;
 
-class DebugCommandFactory
+final class DebugCommandFactory
 {
     public function __invoke(ContainerInterface $container): DebugCommand
     {

--- a/src/Container/Command/FailedMessagesRetryCommandFactory.php
+++ b/src/Container/Command/FailedMessagesRetryCommandFactory.php
@@ -11,7 +11,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Command\FailedMessagesRetryCommand;
 use Symfony\Component\Messenger\RoutableMessageBus;
 
-class FailedMessagesRetryCommandFactory
+final class FailedMessagesRetryCommandFactory
 {
     use FailureTransportRetrievalBehaviour;
 

--- a/src/Container/Command/FailureCommandAbstractFactory.php
+++ b/src/Container/Command/FailureCommandAbstractFactory.php
@@ -15,8 +15,7 @@ use Symfony\Component\Messenger\Command\FailedMessagesShowCommand;
 use function in_array;
 use function sprintf;
 
-/** @final */
-class FailureCommandAbstractFactory
+final class FailureCommandAbstractFactory
 {
     use StaticFactoryContainerAssertion;
     use FailureTransportRetrievalBehaviour;

--- a/src/Container/DoctrineTransportFactory.php
+++ b/src/Container/DoctrineTransportFactory.php
@@ -17,8 +17,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 use function sprintf;
 use function strpos;
 
-/** @final */
-class DoctrineTransportFactory implements TransportFactoryInterface
+final class DoctrineTransportFactory implements TransportFactoryInterface
 {
     public function __construct(private ContainerInterface $container)
     {

--- a/src/Container/MessageBusStaticFactory.php
+++ b/src/Container/MessageBusStaticFactory.php
@@ -8,8 +8,7 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-/** @final */
-class MessageBusStaticFactory
+final class MessageBusStaticFactory
 {
     use MessageBusOptionsRetrievalBehaviour;
     use StaticFactoryContainerAssertion;

--- a/src/Container/Middleware/BusNameStampMiddlewareStaticFactory.php
+++ b/src/Container/Middleware/BusNameStampMiddlewareStaticFactory.php
@@ -8,8 +8,7 @@ use Netglue\PsrContainer\Messenger\Container\StaticFactoryContainerAssertion;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
 
-/** @final */
-class BusNameStampMiddlewareStaticFactory
+final class BusNameStampMiddlewareStaticFactory
 {
     use StaticFactoryContainerAssertion;
 

--- a/src/Container/Middleware/MessageHandlerMiddlewareStaticFactory.php
+++ b/src/Container/Middleware/MessageHandlerMiddlewareStaticFactory.php
@@ -9,8 +9,7 @@ use Netglue\PsrContainer\Messenger\Container\StaticFactoryContainerAssertion;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 
-/** @final */
-class MessageHandlerMiddlewareStaticFactory
+final class MessageHandlerMiddlewareStaticFactory
 {
     use MessageBusOptionsRetrievalBehaviour;
     use StaticFactoryContainerAssertion;

--- a/src/Container/Middleware/MessageSenderMiddlewareStaticFactory.php
+++ b/src/Container/Middleware/MessageSenderMiddlewareStaticFactory.php
@@ -10,8 +10,7 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
 use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
 
-/** @final */
-class MessageSenderMiddlewareStaticFactory
+final class MessageSenderMiddlewareStaticFactory
 {
     use MessageBusOptionsRetrievalBehaviour;
     use StaticFactoryContainerAssertion;

--- a/src/Container/RetryStrategyContainerFactory.php
+++ b/src/Container/RetryStrategyContainerFactory.php
@@ -9,7 +9,7 @@ use Psr\Container\ContainerInterface;
 
 use function is_array;
 
-class RetryStrategyContainerFactory
+final class RetryStrategyContainerFactory
 {
     public function __invoke(ContainerInterface $container): RetryStrategyContainer
     {

--- a/src/Container/TransportFactory.php
+++ b/src/Container/TransportFactory.php
@@ -15,8 +15,7 @@ use function is_array;
 use function is_string;
 use function sprintf;
 
-/** @final */
-class TransportFactory
+final class TransportFactory
 {
     use StaticFactoryContainerAssertion;
 

--- a/src/DefaultCommandBusConfigProvider.php
+++ b/src/DefaultCommandBusConfigProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Netglue\PsrContainer\Messenger;
 
-class DefaultCommandBusConfigProvider
+final class DefaultCommandBusConfigProvider
 {
     /** @return mixed[] */
     public function __invoke(): array

--- a/src/DefaultEventBusConfigProvider.php
+++ b/src/DefaultEventBusConfigProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Netglue\PsrContainer\Messenger;
 
-class DefaultEventBusConfigProvider
+final class DefaultEventBusConfigProvider
 {
     /** @return mixed[] */
     public function __invoke(): array

--- a/src/Exception/BadMethodCall.php
+++ b/src/Exception/BadMethodCall.php
@@ -6,6 +6,6 @@ namespace Netglue\PsrContainer\Messenger\Exception;
 
 use BadMethodCallException;
 
-class BadMethodCall extends BadMethodCallException
+final class BadMethodCall extends BadMethodCallException
 {
 }

--- a/src/Exception/ConfigurationError.php
+++ b/src/Exception/ConfigurationError.php
@@ -6,6 +6,6 @@ namespace Netglue\PsrContainer\Messenger\Exception;
 
 use RuntimeException;
 
-class ConfigurationError extends RuntimeException
+final class ConfigurationError extends RuntimeException
 {
 }

--- a/src/Exception/InvalidServiceType.php
+++ b/src/Exception/InvalidServiceType.php
@@ -7,6 +7,6 @@ namespace Netglue\PsrContainer\Messenger\Exception;
 use Psr\Container\ContainerExceptionInterface;
 use RuntimeException;
 
-class InvalidServiceType extends RuntimeException implements ContainerExceptionInterface
+final class InvalidServiceType extends RuntimeException implements ContainerExceptionInterface
 {
 }

--- a/src/Exception/ServiceNotFound.php
+++ b/src/Exception/ServiceNotFound.php
@@ -9,8 +9,7 @@ use RuntimeException;
 
 use function sprintf;
 
-/** @final */
-class ServiceNotFound extends RuntimeException implements NotFoundExceptionInterface
+final class ServiceNotFound extends RuntimeException implements NotFoundExceptionInterface
 {
     public static function withRetryStrategy(string $transportName): self
     {

--- a/src/Exception/UnknownTransportScheme.php
+++ b/src/Exception/UnknownTransportScheme.php
@@ -6,8 +6,7 @@ namespace Netglue\PsrContainer\Messenger\Exception;
 
 use function sprintf;
 
-/** @final */
-class UnknownTransportScheme extends InvalidArgument
+final class UnknownTransportScheme extends InvalidArgument
 {
     public static function withOffendingString(string $scheme): self
     {

--- a/src/FailureCommandsConfigProvider.php
+++ b/src/FailureCommandsConfigProvider.php
@@ -10,7 +10,7 @@ use Symfony\Component\Messenger\Command\FailedMessagesRemoveCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesRetryCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesShowCommand;
 
-class FailureCommandsConfigProvider
+final class FailureCommandsConfigProvider
 {
     /** @return mixed[] */
     public function __invoke(): array

--- a/src/HandlerLocator/OneToManyFqcnContainerHandlerLocator.php
+++ b/src/HandlerLocator/OneToManyFqcnContainerHandlerLocator.php
@@ -11,8 +11,7 @@ use Symfony\Component\Messenger\Handler\HandlersLocatorInterface;
 
 use function is_array;
 
-/** @final */
-class OneToManyFqcnContainerHandlerLocator implements HandlersLocatorInterface
+final class OneToManyFqcnContainerHandlerLocator implements HandlersLocatorInterface
 {
     /** @param string[][] $handlers */
     public function __construct(private iterable $handlers, private ContainerInterface $container)

--- a/src/HandlerLocator/OneToOneFqcnContainerHandlerLocator.php
+++ b/src/HandlerLocator/OneToOneFqcnContainerHandlerLocator.php
@@ -14,8 +14,7 @@ use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use function assert;
 use function is_string;
 
-/** @final */
-class OneToOneFqcnContainerHandlerLocator implements HandlersLocatorInterface
+final class OneToOneFqcnContainerHandlerLocator implements HandlersLocatorInterface
 {
     /** @param string[] $handlers */
     public function __construct(private iterable $handlers, private ContainerInterface $container)

--- a/src/MessageBusOptions.php
+++ b/src/MessageBusOptions.php
@@ -14,8 +14,7 @@ use function is_a;
 use function iterator_to_array;
 use function sprintf;
 
-/** @final */
-class MessageBusOptions extends AbstractOptions
+final class MessageBusOptions extends AbstractOptions
 {
     /** @var string[] */
     private array $middleware = [];

--- a/src/RetryStrategyContainer.php
+++ b/src/RetryStrategyContainer.php
@@ -15,8 +15,7 @@ use function gettype;
 use function is_object;
 use function sprintf;
 
-/** @final */
-class RetryStrategyContainer implements ContainerInterface
+final class RetryStrategyContainer implements ContainerInterface
 {
     /** @var RetryStrategyInterface[] */
     private array $strategiesIndexedByTransport = [];

--- a/src/TransportFactoryFactory.php
+++ b/src/TransportFactoryFactory.php
@@ -24,6 +24,7 @@ use function trim;
 
 use const PHP_URL_QUERY;
 
+/** @final */
 class TransportFactoryFactory
 {
     public function __invoke(string $dsn, ContainerInterface $container): TransportFactoryInterface


### PR DESCRIPTION
None of the classes shipped were designed for inheritance and should all have been `final`. in the first place.

`TransportFactoryFactory` still requires final but is blocked by existing tests that mock it. The offending test will need to be refactored