### PR TITLE
Replace references to deprecated AMQP and Redis transport factories

### DIFF
--- a/.github/composer-require-checker.json
+++ b/.github/composer-require-checker.json
@@ -4,6 +4,8 @@
         "static", "self", "parent",
         "array", "string", "int", "float", "bool", "iterable", "callable", "void", "object", "mixed", "never",
         "Doctrine\\ORM\\EntityManager",
-        "Laminas\\ServiceManager\\Factory\\InvokableFactory"
+        "Laminas\\ServiceManager\\Factory\\InvokableFactory",
+        "Symfony\\Component\\Messenger\\Bridge\\Amqp\\Transport\\AmqpTransportFactory",
+        "Symfony\\Component\\Messenger\\Bridge\\Redis\\Transport\\RedisTransportFactory"
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,8 @@
         "psalm/plugin-phpunit": "^0.18.4",
         "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.7.2",
+        "symfony/amqp-messenger": "^5.4.22",
+        "symfony/redis-messenger": "^5.4.22",
         "vimeo/psalm": "^5.9"
     },
     "conflict": {
@@ -45,7 +47,9 @@
         "symfony/amqp-messenger": ">=6"
     },
     "suggest": {
-        "laminas/laminas-cli": "To auto-wire symfony cli commands into your DI container with laminas/laminas-cli"
+        "laminas/laminas-cli": "To auto-wire symfony cli commands into your DI container with laminas/laminas-cli",
+        "symfony/amqp-messenger": "To use AMQP transports with Messenger",
+        "symfony/redis-messenger": "To use a Redis transport with Messenger"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54d6324a4f2ce6ed52e6727d7570754b",
+    "content-hash": "fb563c8b70aba751b183c9abf76f57c0",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -4282,12 +4282,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "859e034a7425f6fd0c30c58198f831ac6c7e6bfb"
+                "reference": "487351fe8ec8008c0c5afd095c92b03a2a653ecf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/859e034a7425f6fd0c30c58198f831ac6c7e6bfb",
-                "reference": "859e034a7425f6fd0c30c58198f831ac6c7e6bfb",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/487351fe8ec8008c0c5afd095c92b03a2a653ecf",
+                "reference": "487351fe8ec8008c0c5afd095c92b03a2a653ecf",
                 "shasum": ""
             },
             "conflict": {
@@ -4406,7 +4406,7 @@
                 "ezsystems/ezplatform-graphql": ">=1-rc.1,<1.0.13|>=2-beta.1,<2.3.12",
                 "ezsystems/ezplatform-kernel": "<1.2.5.1|>=1.3,<1.3.26",
                 "ezsystems/ezplatform-rest": ">=1.2,<=1.2.2|>=1.3,<1.3.8",
-                "ezsystems/ezplatform-richtext": ">=2.3,<=2.3.7",
+                "ezsystems/ezplatform-richtext": ">=2.3,<2.3.7.1",
                 "ezsystems/ezplatform-user": ">=1,<1.0.1",
                 "ezsystems/ezpublish-kernel": "<6.13.8.2|>=7,<7.5.30",
                 "ezsystems/ezpublish-legacy": "<=2017.12.7.3|>=2018.6,<=2019.3.5.1",
@@ -4454,7 +4454,7 @@
                 "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
                 "gree/jose": "<2.2.1",
                 "gregwar/rst": "<1.0.3",
-                "grumpydictator/firefly-iii": "<5.8",
+                "grumpydictator/firefly-iii": "<6",
                 "guzzlehttp/guzzle": "<6.5.8|>=7,<7.4.5",
                 "guzzlehttp/psr7": "<1.8.4|>=2,<2.1.1",
                 "harvesthq/chosen": "<1.8.7",
@@ -4607,6 +4607,7 @@
                 "phpxmlrpc/extras": "<0.6.1",
                 "phpxmlrpc/phpxmlrpc": "<4.9.2",
                 "pimcore/data-hub": "<1.2.4",
+                "pimcore/perspective-editor": "<1.5.1",
                 "pimcore/pimcore": "<10.5.20",
                 "pixelfed/pixelfed": "<=0.11.4",
                 "pocketmine/bedrock-protocol": "<8.0.2",
@@ -4871,7 +4872,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-31T23:04:35+00:00"
+            "time": "2023-04-03T21:04:12+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -232,20 +232,8 @@
     </MixedAssignment>
   </file>
   <file src="src/TransportFactoryFactory.php">
-    <DeprecatedClass>
-      <code>new AmqpTransportFactory()</code>
-      <code>new RedisTransportFactory()</code>
-    </DeprecatedClass>
-    <InvalidReturnStatement>
-      <code>new AmqpTransportFactory()</code>
-      <code>new RedisTransportFactory()</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code>TransportFactoryInterface</code>
-    </InvalidReturnType>
     <MixedArgument>
       <code><![CDATA[$container->get(trim($config, '/'))]]></code>
-      <code>$name</code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$config['symfony']]]></code>
@@ -254,7 +242,6 @@
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$config</code>
-      <code>$name</code>
       <code>$transportFactories</code>
     </MixedAssignment>
   </file>
@@ -477,10 +464,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="tests/TransportFactoryFactoryTest.php">
-    <DeprecatedClass>
-      <code>AmqpTransportFactory::class</code>
-      <code>RedisTransportFactory::class</code>
-    </DeprecatedClass>
     <MixedMethodCall>
       <code>willReturn</code>
     </MixedMethodCall>

--- a/src/Exception/MissingDependency.php
+++ b/src/Exception/MissingDependency.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\PsrContainer\Messenger\Exception;
+
+use RuntimeException;
+
+use function sprintf;
+
+final class MissingDependency extends RuntimeException
+{
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $package
+     */
+    public static function forTransport(string $name, string $package): self
+    {
+        return new self(sprintf(
+            'Transports of type "%s" require that the composer package "%s" is installed.',
+            $name,
+            $package,
+        ));
+    }
+}

--- a/src/TransportFactoryFactory.php
+++ b/src/TransportFactoryFactory.php
@@ -6,17 +6,20 @@ namespace Netglue\PsrContainer\Messenger;
 
 use Netglue\PsrContainer\Messenger\Container\DoctrineTransportFactory;
 use Netglue\PsrContainer\Messenger\Exception\ConfigurationError;
+use Netglue\PsrContainer\Messenger\Exception\MissingDependency;
 use Netglue\PsrContainer\Messenger\Exception\UnknownTransportScheme;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransportFactory;
+use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
+use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\Transport\InMemoryTransportFactory;
-use Symfony\Component\Messenger\Transport\RedisExt\RedisTransportFactory;
 use Symfony\Component\Messenger\Transport\Sync\SyncTransportFactory;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 
 use function assert;
+use function class_exists;
 use function count;
 use function explode;
+use function is_string;
 use function parse_str;
 use function parse_url;
 use function sprintf;
@@ -34,6 +37,10 @@ class TransportFactoryFactory
         [$scheme, $config] = $parts;
         switch ($scheme) {
             case 'amqp':
+                if (! class_exists(AmqpTransportFactory::class)) {
+                    throw MissingDependency::forTransport('amqp', 'symfony/amqp-messenger');
+                }
+
                 return new AmqpTransportFactory();
 
             case 'doctrine':
@@ -43,6 +50,10 @@ class TransportFactoryFactory
                 return new InMemoryTransportFactory();
 
             case 'redis':
+                if (! class_exists(RedisTransportFactory::class)) {
+                    throw MissingDependency::forTransport('redis', 'symfony/redis-messenger');
+                }
+
                 return new RedisTransportFactory();
 
             case 'sync':
@@ -54,6 +65,7 @@ class TransportFactoryFactory
         $config = $container->has('config') ? $container->get('config') : [];
         $transportFactories = $config['symfony']['messenger']['transport_factories'] ?? [];
         foreach ($transportFactories as $name) {
+            assert(is_string($name));
             $factory = $container->get($name);
             if (! $factory instanceof TransportFactoryInterface) {
                 throw new ConfigurationError(sprintf(

--- a/tests/Exception/MissingDependencyTest.php
+++ b/tests/Exception/MissingDependencyTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\PsrContainer\MessengerTest\Exception;
+
+use Netglue\PsrContainer\Messenger\Exception\MissingDependency;
+use PHPUnit\Framework\TestCase;
+
+class MissingDependencyTest extends TestCase
+{
+    public function testThatTheTransportAndPackageArePresentForTransportRelatedErrorMessages(): void
+    {
+        $e = MissingDependency::forTransport('some-transport', 'some-package');
+        self::assertStringContainsString('"some-transport"', $e->getMessage());
+        self::assertStringContainsString('"some-package"', $e->getMessage());
+    }
+}

--- a/tests/TransportFactoryFactoryTest.php
+++ b/tests/TransportFactoryFactoryTest.php
@@ -13,10 +13,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use stdClass;
+use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
+use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\MessageBus;
-use Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransportFactory;
 use Symfony\Component\Messenger\Transport\InMemoryTransportFactory;
-use Symfony\Component\Messenger\Transport\RedisExt\RedisTransportFactory;
 use Symfony\Component\Messenger\Transport\Sync\SyncTransportFactory;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 


### PR DESCRIPTION
Redis and AMQP transports have been moved into separate libraries. v6 of messenger drops the original shipped implementations.

Introduces a new Exception type `MissingDependency` that is thrown when either of these transports are requested but have not been installed with composer.