### PR TITLE
Deprecate 'Helper' traits

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
   <file src="src/Container/Command/ConsumeCommandFactory.php">
+    <DeprecatedTrait>
+      <code>FailureTransportRetrievalBehaviour</code>
+    </DeprecatedTrait>
     <InvalidArgument>
       <code><![CDATA[$this->getFailureTransport($container)]]></code>
     </InvalidArgument>
@@ -51,6 +54,9 @@
     </MixedAssignment>
   </file>
   <file src="src/Container/Command/FailedMessagesRetryCommandFactory.php">
+    <DeprecatedTrait>
+      <code>FailureTransportRetrievalBehaviour</code>
+    </DeprecatedTrait>
     <MixedArgument>
       <code>$logger</code>
       <code>$logger</code>
@@ -67,6 +73,10 @@
     </MixedAssignment>
   </file>
   <file src="src/Container/Command/FailureCommandAbstractFactory.php">
+    <DeprecatedTrait>
+      <code>FailureTransportRetrievalBehaviour</code>
+      <code>StaticFactoryContainerAssertion</code>
+    </DeprecatedTrait>
     <DocblockTypeContradiction>
       <code>in_array($commandName, self::CAN_CREATE, true)</code>
     </DocblockTypeContradiction>
@@ -131,6 +141,10 @@
     </MixedAssignment>
   </file>
   <file src="src/Container/MessageBusStaticFactory.php">
+    <DeprecatedTrait>
+      <code>MessageBusOptionsRetrievalBehaviour</code>
+      <code>StaticFactoryContainerAssertion</code>
+    </DeprecatedTrait>
     <MixedAssignment>
       <code>$middleware[]</code>
     </MixedAssignment>
@@ -138,7 +152,16 @@
       <code>$middleware</code>
     </PossiblyInvalidArgument>
   </file>
+  <file src="src/Container/Middleware/BusNameStampMiddlewareStaticFactory.php">
+    <DeprecatedTrait>
+      <code>StaticFactoryContainerAssertion</code>
+    </DeprecatedTrait>
+  </file>
   <file src="src/Container/Middleware/MessageHandlerMiddlewareStaticFactory.php">
+    <DeprecatedTrait>
+      <code>MessageBusOptionsRetrievalBehaviour</code>
+      <code>StaticFactoryContainerAssertion</code>
+    </DeprecatedTrait>
     <InvalidStringClass>
       <code><![CDATA[new $locatorClass($options->handlers(), $container)]]></code>
     </InvalidStringClass>
@@ -151,6 +174,10 @@
     </MixedAssignment>
   </file>
   <file src="src/Container/Middleware/MessageSenderMiddlewareStaticFactory.php">
+    <DeprecatedTrait>
+      <code>MessageBusOptionsRetrievalBehaviour</code>
+      <code>StaticFactoryContainerAssertion</code>
+    </DeprecatedTrait>
     <MixedArgument>
       <code><![CDATA[$container->get(
                     $options->logger(),
@@ -174,6 +201,9 @@
     </MixedAssignment>
   </file>
   <file src="src/Container/TransportFactory.php">
+    <DeprecatedTrait>
+      <code>StaticFactoryContainerAssertion</code>
+    </DeprecatedTrait>
     <MixedArgument>
       <code><![CDATA[$options['options'] ?? []]]></code>
       <code>$serializer</code>
@@ -259,6 +289,9 @@
     </MixedAssignment>
   </file>
   <file src="tests/Container/MessageBusOptionsRetrievalBehaviourTest.php">
+    <DeprecatedTrait>
+      <code>MessageBusOptionsRetrievalBehaviour</code>
+    </DeprecatedTrait>
     <MixedAssignment>
       <code>$options</code>
     </MixedAssignment>
@@ -311,6 +344,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="tests/Container/StaticFactoryContainerAssertionTest.php">
+    <DeprecatedTrait>
+      <code>StaticFactoryContainerAssertion</code>
+    </DeprecatedTrait>
     <MixedMethodCall>
       <code>callStatic</code>
       <code>callStatic</code>

--- a/src/Container/FailureTransportRetrievalBehaviour.php
+++ b/src/Container/FailureTransportRetrievalBehaviour.php
@@ -11,6 +11,10 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 use function is_string;
 use function sprintf;
 
+/**
+ * @internal
+ * @deprecated This trait will be removed in version 2.0.0
+ */
 trait FailureTransportRetrievalBehaviour
 {
     private function hasFailureTransport(ContainerInterface $container): bool

--- a/src/Container/MessageBusOptionsRetrievalBehaviour.php
+++ b/src/Container/MessageBusOptionsRetrievalBehaviour.php
@@ -7,6 +7,10 @@ namespace Netglue\PsrContainer\Messenger\Container;
 use Netglue\PsrContainer\Messenger\MessageBusOptions;
 use Psr\Container\ContainerInterface;
 
+/**
+ * @internal
+ * @deprecated This trait will be removed in version 2.0.0
+ */
 trait MessageBusOptionsRetrievalBehaviour
 {
     private function options(ContainerInterface $container, string $busIdentifier): MessageBusOptions

--- a/src/Container/StaticFactoryContainerAssertion.php
+++ b/src/Container/StaticFactoryContainerAssertion.php
@@ -9,6 +9,10 @@ use Psr\Container\ContainerInterface;
 
 use function sprintf;
 
+/**
+ * @internal
+ * @deprecated This trait will be removed in version 2.0.0
+ */
 trait StaticFactoryContainerAssertion
 {
     /** @param mixed[] $arguments */


### PR DESCRIPTION
These traits are a pain is the ass for testing and static analysis and can easily be re-written as static utility methods