### PR TITLE
Automatically attach a sigterm listener to the message consumer

### DIFF
--- a/src/Container/Command/ConsumeCommandFactory.php
+++ b/src/Container/Command/ConsumeCommandFactory.php
@@ -14,6 +14,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnSigtermSignalListener;
 use Symfony\Component\Messenger\RoutableMessageBus;
 
 use function array_keys;
@@ -44,6 +45,9 @@ final class ConsumeCommandFactory
             $container->get(FailureSendersProvider::class),
             $logger,
         ));
+
+        // Always adds a listener to gracefully shut-down workers when SIGTERM is received
+        $dispatcher->addSubscriber(new StopWorkerOnSigtermSignalListener($logger));
 
         return new ConsumeMessagesCommand(
             new RoutableMessageBus($container),


### PR DESCRIPTION
Changes the factory for the `ConsumeMessagesCommand` so that `StopWorkerOnSigtermSignalListener` is attached. This will mean that workers will be stopped gracefully when the worker is terminated.

This is considered a BC break because it is likely that users of this library were already doing this by way of a delegator factory _(I certainly am)_, so this patch will result in duplicate listeners unless consumers update their code accordingly.

Closes #108