### PR TITLE
Improve type inference and test coverage.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
-  <file src="src/Container/Command/DebugCommandFactory.php">
-    <MixedAssignment>
-      <code>$handler</code>
-      <code>$handlerList</code>
-    </MixedAssignment>
-  </file>
   <file src="src/Container/DoctrineTransportFactory.php">
     <InternalClass>
       <code>Connection::buildConfiguration($dsn, $options)</code>
@@ -17,25 +11,6 @@
     </InternalMethod>
     <MixedArgument>
       <code><![CDATA[$configuration['connection']]]></code>
-    </MixedArgument>
-  </file>
-  <file src="src/Container/Middleware/MessageHandlerMiddlewareStaticFactory.php">
-    <InvalidStringClass>
-      <code><![CDATA[new $locatorClass($options->handlers(), $container)]]></code>
-    </InvalidStringClass>
-    <MixedArgument>
-      <code><![CDATA[$container->get($options->logger())]]></code>
-      <code>$locator</code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code>$locator</code>
-    </MixedAssignment>
-  </file>
-  <file src="src/Container/Middleware/MessageSenderMiddlewareStaticFactory.php">
-    <MixedArgument>
-      <code><![CDATA[$container->get(
-                    $options->logger(),
-                )]]></code>
     </MixedArgument>
   </file>
   <file src="tests/Container/TransportFactoryTest.php">

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -7,6 +7,7 @@ namespace Netglue\PsrContainer\Messenger;
 use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Symfony\Component\Messenger as SymfonyMessenger;
+use Symfony\Component\Messenger\Handler\HandlersLocatorInterface;
 
 /**
  * @psalm-import-type ServiceManagerConfigurationType from ConfigInterface
@@ -25,9 +26,10 @@ use Symfony\Component\Messenger as SymfonyMessenger;
  * @psalm-type BusConfig = array{
  *     allows_zero_handlers: bool,
  *     middleware: list<string>,
- *     handler_locator: string,
+ *     handler_locator: class-string<HandlersLocatorInterface>,
  *     handlers: array<string, string|list<string>>,
  *     routes: array<string, list<string>>,
+ *     logger?: string|null,
  * }
  * @psalm-type MessengerConfig = array{
  *     logger?: string|null,

--- a/src/Container/Command/DebugCommandFactory.php
+++ b/src/Container/Command/DebugCommandFactory.php
@@ -4,39 +4,28 @@ declare(strict_types=1);
 
 namespace Netglue\PsrContainer\Messenger\Container\Command;
 
-use GSteel\Dot;
 use Netglue\PsrContainer\Messenger\Container\Util;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Messenger\Command\DebugCommand;
 
-use function assert;
-use function is_array;
 use function is_string;
 
 final class DebugCommandFactory
 {
     public function __invoke(ContainerInterface $container): DebugCommand
     {
-        $config = Util::applicationConfig($container);
-        $busList = Dot::arrayDefault('symfony.messenger.buses', $config, []);
+        $busList = Util::busConfiguration($container);
         $map = [];
         foreach ($busList as $bus => $busConfig) {
-            assert(is_string($bus));
-            assert(is_array($busConfig));
-
             $handlers = $busConfig['handlers'] ?? [];
-            assert(is_array($handlers));
             $map[$bus] = [];
             foreach ($handlers as $message => $handlerList) {
-                assert(is_array($handlerList) || is_string($handlerList));
-
                 $map[$bus][$message] = [];
                 if (is_string($handlerList)) {
                     $handlerList = [$handlerList];
                 }
 
                 foreach ($handlerList as $handler) {
-                    assert(is_string($handler));
                     $map[$bus][$message][] = [$handler, []];
                 }
             }

--- a/src/Container/Middleware/MessageHandlerMiddlewareStaticFactory.php
+++ b/src/Container/Middleware/MessageHandlerMiddlewareStaticFactory.php
@@ -6,7 +6,11 @@ namespace Netglue\PsrContainer\Messenger\Container\Middleware;
 
 use Netglue\PsrContainer\Messenger\Container\Util;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Handler\HandlersLocatorInterface;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+
+use function assert;
 
 final class MessageHandlerMiddlewareStaticFactory
 {
@@ -21,15 +25,15 @@ final class MessageHandlerMiddlewareStaticFactory
         $locatorClass = $options->handlerLocator();
         $locator = $container->has($locatorClass) ? $container->get($locatorClass) : null;
 
-        if (! $locator) {
+        if (! $locator instanceof HandlersLocatorInterface) {
             $locator = new $locatorClass($options->handlers(), $container);
         }
 
         $middleware = new HandleMessageMiddleware($locator, $options->allowsZeroHandlers());
         if ($options->logger()) {
-            $middleware->setLogger(
-                $container->get($options->logger()),
-            );
+            $logger = $container->get($options->logger());
+            assert($logger instanceof LoggerInterface);
+            $middleware->setLogger($logger);
         }
 
         return $middleware;

--- a/src/Container/Middleware/MessageSenderMiddlewareStaticFactory.php
+++ b/src/Container/Middleware/MessageSenderMiddlewareStaticFactory.php
@@ -6,8 +6,11 @@ namespace Netglue\PsrContainer\Messenger\Container\Middleware;
 
 use Netglue\PsrContainer\Messenger\Container\Util;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
 use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+
+use function assert;
 
 final class MessageSenderMiddlewareStaticFactory
 {
@@ -27,11 +30,9 @@ final class MessageSenderMiddlewareStaticFactory
 
         $middleware = new SendMessageMiddleware($transportRouter);
         if ($options->logger()) {
-            $middleware->setLogger(
-                $container->get(
-                    $options->logger(),
-                ),
-            );
+            $logger = $container->get($options->logger());
+            assert($logger instanceof LoggerInterface);
+            $middleware->setLogger($logger);
         }
 
         return $middleware;

--- a/src/MessageBusOptions.php
+++ b/src/MessageBusOptions.php
@@ -24,7 +24,7 @@ final class MessageBusOptions extends AbstractOptions
     private array $routes = [];
     private string|null $logger = null;
     private bool $allowsZeroHandlers = false;
-    /** @var class-string */
+    /** @var class-string<HandlersLocatorInterface> */
     private string $handlerLocator = OneToManyFqcnContainerHandlerLocator::class;
 
     /** @param string[] $middleware */
@@ -51,6 +51,7 @@ final class MessageBusOptions extends AbstractOptions
         return $this->handlers;
     }
 
+    /** @param class-string<HandlersLocatorInterface> $handlerLocator */
     public function setHandlerLocator(string $handlerLocator): void
     {
         if (! is_a($handlerLocator, HandlersLocatorInterface::class, true)) {
@@ -63,6 +64,7 @@ final class MessageBusOptions extends AbstractOptions
         $this->handlerLocator = $handlerLocator;
     }
 
+    /** @return class-string<HandlersLocatorInterface> */
     public function handlerLocator(): string
     {
         return $this->handlerLocator;

--- a/tests/Container/Middleware/MessageHandlerMiddlewareStaticFactoryTest.php
+++ b/tests/Container/Middleware/MessageHandlerMiddlewareStaticFactoryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\PsrContainer\MessengerTest\Container\Middleware;
+
+use Netglue\PsrContainer\Messenger\Container\Middleware\MessageHandlerMiddlewareStaticFactory;
+use Netglue\PsrContainer\Messenger\HandlerLocator\OneToManyFqcnContainerHandlerLocator;
+use Netglue\PsrContainer\MessengerTest\InMemoryContainer;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionProperty;
+use Symfony\Component\Messenger\Handler\HandlersLocatorInterface;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+
+class MessageHandlerMiddlewareStaticFactoryTest extends TestCase
+{
+    private InMemoryContainer $container;
+    private MessageHandlerMiddlewareStaticFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = new InMemoryContainer();
+        $this->factory = new MessageHandlerMiddlewareStaticFactory('my_bus');
+    }
+
+    public function testThatMiddlewareIsProducedWhenTheLocatorIsDefinedInTheContainer(): void
+    {
+        $this->container->setService('config', [
+            'symfony' => [
+                'messenger' => [
+                    'buses' => [
+                        'my_bus' => [
+                            'handler_locator' => OneToManyFqcnContainerHandlerLocator::class,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $locator = $this->createMock(HandlersLocatorInterface::class);
+
+        $this->container->setService(OneToManyFqcnContainerHandlerLocator::class, $locator);
+
+        $middleware = $this->factory->__invoke($this->container);
+
+        self::assertInstanceOf(HandleMessageMiddleware::class, $middleware);
+    }
+
+    public function testThatMiddlewareIsProducedWhenTheLocatorIsNotDefinedInTheContainer(): void
+    {
+        $this->container->setService('config', [
+            'symfony' => [
+                'messenger' => [
+                    'buses' => [
+                        'my_bus' => [
+                            'handler_locator' => OneToManyFqcnContainerHandlerLocator::class,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $middleware = $this->factory->__invoke($this->container);
+        self::assertInstanceOf(HandleMessageMiddleware::class, $middleware);
+    }
+
+    public function testThatMiddlewareIsProducedWhenTheLocatorIsCompletelyUndefined(): void
+    {
+        $this->container->setService('config', [
+            'symfony' => [
+                'messenger' => [
+                    'buses' => [
+                        'my_bus' => [],
+                    ],
+                ],
+            ],
+        ]);
+
+        $middleware = $this->factory->__invoke($this->container);
+        self::assertInstanceOf(HandleMessageMiddleware::class, $middleware);
+    }
+
+    public function testThatTheDefinedLoggerWillBeComposed(): void
+    {
+        $this->container->setService('config', [
+            'symfony' => [
+                'messenger' => [
+                    'buses' => [
+                        'my_bus' => ['logger' => 'myLogger'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $this->container->setService('myLogger', $logger);
+        $middleware = $this->factory->__invoke($this->container);
+        $prop = new ReflectionProperty($middleware, 'logger');
+        self::assertSame($logger, $prop->getValue($middleware));
+    }
+}

--- a/tests/Container/Middleware/MessageSenderMiddlewareStaticFactoryTest.php
+++ b/tests/Container/Middleware/MessageSenderMiddlewareStaticFactoryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netglue\PsrContainer\MessengerTest\Container\Middleware;
+
+use Netglue\PsrContainer\Messenger\Container\Middleware\MessageSenderMiddlewareStaticFactory;
+use Netglue\PsrContainer\MessengerTest\InMemoryContainer;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionProperty;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+
+class MessageSenderMiddlewareStaticFactoryTest extends TestCase
+{
+    private InMemoryContainer $container;
+    private MessageSenderMiddlewareStaticFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = new InMemoryContainer();
+        $this->factory = new MessageSenderMiddlewareStaticFactory('my_bus');
+    }
+
+    public function testMiddlewareIsProducedWithZeroConfig(): void
+    {
+        $this->container->setService('config', [
+            'symfony' => [
+                'messenger' => [
+                    'buses' => [
+                        'my_bus' => [],
+                    ],
+                ],
+            ],
+        ]);
+
+        $middleware = $this->factory->__invoke($this->container);
+        self::assertInstanceOf(SendMessageMiddleware::class, $middleware);
+    }
+
+    public function testMiddlewareIsComposedWithALoggerWhenConfigured(): void
+    {
+        $this->container->setService('config', [
+            'symfony' => [
+                'messenger' => [
+                    'buses' => [
+                        'my_bus' => ['logger' => 'myLogger'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $this->container->setService('myLogger', $logger);
+
+        $middleware = $this->factory->__invoke($this->container);
+
+        $prop = new ReflectionProperty($middleware, 'logger');
+        self::assertSame($logger, $prop->getValue($middleware));
+    }
+}

--- a/tests/MessageBusOptionsTest.php
+++ b/tests/MessageBusOptionsTest.php
@@ -66,10 +66,11 @@ class MessageBusOptionsTest extends TestCase
     {
         $this->expectException(InvalidArgument::class);
         $this->expectExceptionMessage('Handler locators must implement');
+        /** @psalm-suppress InvalidArgument */
         $this->options->setHandlerLocator(self::class);
     }
 
-    /** @return array<array-key, array{0: class-string}> */
+    /** @return array<array-key, array{0: class-string<HandlersLocatorInterface>}> */
     public static function handlerLocatorTypes(): iterable
     {
         return [
@@ -80,7 +81,7 @@ class MessageBusOptionsTest extends TestCase
         ];
     }
 
-    /** @param class-string $type */
+    /** @param class-string<HandlersLocatorInterface> $type */
     #[DataProvider('handlerLocatorTypes')]
     public function testValidKnownLocatorTypes(string $type): void
     {


### PR DESCRIPTION
- Documents the ability to set a bus-specific logger
- Documents that the bus option `handler_locator` must be `class-string<HandlersLocatorInterface>`