### PR TITLE
Remove composer conflicts with previously incompatible libs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 /.github/ export-ignore
-/tests/ export-ignore=
+/tests/ export-ignore
 /composer.lock export-ignore
 /composer-require-checker.json export-ignore
 /renovate.json export-ignore
@@ -9,3 +9,4 @@
 /phpunit.xml.dist export-ignore
 /psalm.xml export-ignore
 /psalm-baseline.xml export-ignore
+/.laminas-ci.json export-ignore

--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,6 @@
+{
+    "extensions": [
+        "redis",
+        "igbinary"
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -47,10 +47,6 @@
         "symfony/redis-messenger": "^5.4.22 || ^6.0",
         "vimeo/psalm": "^5.9"
     },
-    "conflict": {
-        "symfony/redis-messenger": ">=6",
-        "symfony/amqp-messenger": ">=6"
-    },
     "suggest": {
         "laminas/laminas-cli": "To auto-wire symfony cli commands into your DI container with laminas/laminas-cli",
         "symfony/amqp-messenger": "To use AMQP transports with Messenger",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7b27253820a81c75796e9b2e65ce069",
+    "content-hash": "7c95b531482015244f2de52c66de3ab6",
     "packages": [
         {
             "name": "gsteel/dot",
@@ -6619,26 +6619,26 @@
         },
         {
             "name": "symfony/redis-messenger",
-            "version": "v5.4.22",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/redis-messenger.git",
-                "reference": "b511d76ae72bff8d3a316f632c200368e52bcf61"
+                "reference": "c08eb56f9ecefb10162d4b84d51ccbacdda7cca7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/redis-messenger/zipball/b511d76ae72bff8d3a316f632c200368e52bcf61",
-                "reference": "b511d76ae72bff8d3a316f632c200368e52bcf61",
+                "url": "https://api.github.com/repos/symfony/redis-messenger/zipball/c08eb56f9ecefb10162d4b84d51ccbacdda7cca7",
+                "reference": "c08eb56f9ecefb10162d4b84d51ccbacdda7cca7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/messenger": "^5.1|^6.0"
+                "ext-redis": "*",
+                "php": ">=8.1",
+                "symfony/messenger": "^6.1"
             },
             "require-dev": {
-                "symfony/property-access": "^4.4|^5.0|^6.0",
-                "symfony/serializer": "^4.4|^5.0|^6.0"
+                "symfony/property-access": "^5.4|^6.0",
+                "symfony/serializer": "^5.4|^6.0"
             },
             "type": "symfony-messenger-bridge",
             "autoload": {
@@ -6666,7 +6666,7 @@
             "description": "Symfony Redis extension Messenger Bridge",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/redis-messenger/tree/v5.4.22"
+                "source": "https://github.com/symfony/redis-messenger/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -6682,7 +6682,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-10T09:58:14+00:00"
+            "time": "2023-03-10T10:06:03+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
Removes redundant conflicts with `symfony/redis-messenger` and `symfony/amqp-messenger` in the 6.x series