### PR TITLE
Remove CodeCov integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,23 +16,6 @@ jobs:
   ci:
     uses: laminas/workflow-continuous-integration/.github/workflows/continuous-integration.yml@1.x
 
-  coverage:
-    name: 'Test Coverage'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: shivammathur/setup-php@2.24.0
-        with:
-          php-version: ${{ env.default_php }}
-          extensions: ${{ env.php_extensions }}
-          coverage: pcov
-          ini-values: pcov.enabled=1
-      - uses: ramsey/composer-install@2.2.0
-      - run: php ./vendor/bin/phpunit --coverage-clover=coverage.xml
-      - uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml
-          fail_ci_if_error: false
   #
   # Use custom require-checker run - Laminas CI requires it's installed as a dev dependency for now.
   #

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 # Mezzio/Laminas Factories for Symfony Messenger
 
 ![Continuous Integration](https://github.com/netglue/laminas-messenger/workflows/Continuous%20Integration/badge.svg)
-[![codecov](https://codecov.io/gh/netglue/laminas-messenger/branch/main/graph/badge.svg)](https://codecov.io/gh/netglue/laminas-messenger)
 [![Type Coverage](https://shepherd.dev/github/netglue/laminas-messenger/coverage.svg)](https://shepherd.dev/github/netglue/laminas-messenger)
 ### Introduction
 


### PR DESCRIPTION
The coverage badge on the readme is misleading because it can't handle the version based branching strategy and the reports are rarely useful, just causing CI to fail periodically.