### PR TITLE
Fix symfony 7 deprecations in FailureCommandsConfigProvider

### DIFF
--- a/src/FailureCommandsConfigProvider.php
+++ b/src/FailureCommandsConfigProvider.php
@@ -11,9 +11,6 @@ use Symfony\Component\Messenger\Command\FailedMessagesRemoveCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesRetryCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesShowCommand;
 
-use function assert;
-use function is_string;
-
 /** @psalm-import-type ServiceManagerConfiguration from ServiceManager */
 final class FailureCommandsConfigProvider
 {
@@ -43,17 +40,10 @@ final class FailureCommandsConfigProvider
     {
         return [
             'commands' => [
-                self::assertCommandName(FailedMessagesRemoveCommand::getDefaultName()) => FailedMessagesRemoveCommand::class,
-                self::assertCommandName(FailedMessagesRetryCommand::getDefaultName()) => FailedMessagesRetryCommand::class,
-                self::assertCommandName(FailedMessagesShowCommand::getDefaultName()) => FailedMessagesShowCommand::class,
+                'messenger:failed:remove' => FailedMessagesRemoveCommand::class,
+                'messenger:failed:retry' => FailedMessagesRetryCommand::class,
+                'messenger:failed:show' => FailedMessagesShowCommand::class,
             ],
         ];
-    }
-
-    private static function assertCommandName(string|null $name): string
-    {
-        assert(is_string($name) && $name !== '');
-
-        return $name;
     }
 }


### PR DESCRIPTION
Fixes `PHP Deprecated: Since symfony/console 7.3: Method "Symfony\Component\Console\Command\Command::getDefaultName()" is deprecated and will be removed in Symfony 8.0, use the #[AsCommand] attribute instead. in /var/www/vendor/symfony/deprecation-contracts/function.php on line 25`

From what I can tell my change is already covered by `LaminasCliIntegrationTest`?